### PR TITLE
update current activity

### DIFF
--- a/android/src/main/java/com/androidphonenumberhint/AndroidPhoneNumberHintModule.kt
+++ b/android/src/main/java/com/androidphonenumberhint/AndroidPhoneNumberHintModule.kt
@@ -59,7 +59,7 @@ class AndroidPhoneNumberHintModule(reactContext: ReactApplicationContext) : Reac
     }
 
     mPromise = promise
-    val activity = currentActivity
+    val activity = reactApplicationContext.currentActivity
     if (activity == null) {
       mPromise = null
       promise.reject("NO_ACTIVITY", "Activity is null")


### PR DESCRIPTION
After upgrading our React-Native version to 0.81.0 Android build fails with the error:
Fix `Unresolved reference 'currentActivity'.` 

React Native deprecated the currentActivity property in 0.80, and removed it in 0.81 